### PR TITLE
[cli/oar2trace] filters AssignedResources query

### DIFF
--- a/oar/cli/oar2trace.py
+++ b/oar/cli/oar2trace.py
@@ -145,6 +145,8 @@ def get_jobs(first_jobid, last_jobid, wkld_metadata):
 
     # Determine nb_default_ressources and nb_extra_ressources for jobs in Terminated or Error state
     result = db.query(AssignedResource)\
+               .filter(AssignedResource.moldable_id >= min_mld_id)\
+               .filter(AssignedResource.moldable_id <= max_mld_id)\
                .order_by(AssignedResource.moldable_id, AssignedResource.resource_id)
 
     moldable_id = 0

--- a/oar/cli/oar2trace.py
+++ b/oar/cli/oar2trace.py
@@ -433,9 +433,9 @@ def cli(db_url, trace_file, first_jobid, last_jobid, chunk_size, metadata_file, 
             end_jobid = last_jobid
         else:
             end_jobid = begin_jobid + chunk_size - 1
-        print('# Jobids Range: [{}-{}], Chunck: {}'.format(first_jobid, end_jobid, (chunk + 1)))
+        print('# Jobids Range: [{}-{}], Chunck: {}'.format(begin_jobid, end_jobid, (chunk + 1)))
 
-        jobs_metrics = get_jobs(first_jobid, end_jobid, wkld_metadata)
+        jobs_metrics = get_jobs(begin_jobid, end_jobid, wkld_metadata)
         jobs2trace(jobs_metrics, fh, unix_start_time, mode, display)
 
         begin_jobid = end_jobid + 1


### PR DESCRIPTION
Hello,
I found a bug causing the oar2trace script pulling off the entire AssignedResources table at each chunks.

The fix adds the same filter as for this [query](https://github.com/oar-team/oar3/blob/b731ec9787f429b5c4ece7cff7078ea5535a1c8a/oar/cli/oar2trace.py#L136).

```
pytest tests/cli/test_oar2trace.py
========================================= test session starts ==========================================
platform linux -- Python 3.7.3, pytest-4.2.1, py-1.7.0, pluggy-0.8.1 -- /nix/store/0n8slcq8p5x31kc9hncabsqq9y3fpkzp-python3-3.7.3/bin/python3.7
cachedir: .pytest_cache
rootdir: /home/adfaure/Projects/oar3, inifile: setup.cfg
plugins: flask-0.14.0
collected 2 items                                                                                      

tests/cli/test_oar2trace.py::test_oar2trace_void PASSED                                          [ 50%]
tests/cli/test_oar2trace.py::test_oar2trace_simple SKIPPED                                       [100%]

================================= 1 passed, 1 skipped in 0.06 seconds ==================================
```