### PR TITLE
[Monika] Fixing Resource IDs order to be numerically

### DIFF
--- a/visualization_interfaces/Monika/lib/OAR/Monika/OARJob.pm
+++ b/visualization_interfaces/Monika/lib/OAR/Monika/OARJob.pm
@@ -9,6 +9,7 @@ use strict;
 use OAR::Monika::monikaCGI;
 use File::Basename;
 use Data::Dumper;
+use Sort::Naturally;
 
 my $bestEffortColor = "#dddddd";
 
@@ -155,7 +156,7 @@ sub htmlStatusTable {
   $output .= $cgi->th({-align => "left"}, $self->jobId());
   $output .= $cgi->end_Tr();
   my @keylist = keys %{$self};
-  foreach my $key (sort @keylist) {
+  foreach my $key (sort {$a <=> $b or Sort::Naturally::ncmp($a,$b)} @keylist) {
     if(($key eq "job_id")){
     #if(($key eq "job_id") or ($key eq "initial_request")){
       next;

--- a/visualization_interfaces/Monika/lib/OAR/Monika/OARNode.pm
+++ b/visualization_interfaces/Monika/lib/OAR/Monika/OARNode.pm
@@ -10,6 +10,7 @@ use OAR::Monika::monikaCGI;
 use OAR::Monika::Conf;
 use Data::Dumper;
 use Time::Local;
+use Sort::Naturally;
 use POSIX qw(strftime);
 
 ## class constructor
@@ -162,7 +163,7 @@ sub htmlTable {
   my $cgiName = File::Basename::basename($cgi->self_url(-query=>0));
   my $max_cores_per_line = OAR::Monika::Conf::myself()->max_cores_per_line();
   my $nb_cells = 0;
-  foreach my $currentRessource (sort keys %{$self->{Ressources}}){
+  foreach my $currentRessource (sort {$a <=> $b or Sort::Naturally::ncmp($a,$b)} keys %{$self->{Ressources}}){
     if (($nb_cells++ % $max_cores_per_line) == 0){
         $output .= $cgi->end_Tr();
         $output .= $cgi->start_Tr({-align => "center"});
@@ -258,15 +259,15 @@ sub htmlStatusTable {
   my @properties= keys %{$self->{Ressources}->{$keylist[0]}->{infos}};
   $output .= $cgi->start_Tr();
   $output .= $cgi->th({-align => "left", bgcolor => "^c0c0c0"}, $cgi->i("Ressource no."));
-  foreach my $key (sort @keylist) {
+  foreach my $key (sort {$a <=> $b or Sort::Naturally::ncmp($a,$b)} @keylist) {
     $output .= $cgi->th({-align => "left", bgcolor => "^c0c0c0"}, $cgi->i($key));
   }
   $output .= $cgi->end_Tr();
 
-  foreach my $prop (@properties) {
+  foreach my $prop (sort {$a <=> $b or Sort::Naturally::ncmp($a,$b)} @properties) {
     $output .= $cgi->start_Tr();
     $output .= $cgi->th({-align => "left", bgcolor => "^c0c0c0"}, $cgi->i($prop));
-    foreach my $key (sort @keylist) {
+    foreach my $key (sort {$a <=> $b or Sort::Naturally::ncmp($a,$b)} @keylist) {
       my $value= $self->{Ressources}->{$key}->{infos}->{$prop};
       if($prop eq $nodes_synonym){
         $value= $self->displayHTMLname();


### PR DESCRIPTION
This PR is designated for the `Monika` visualization interface and fixes the following:

- The order of the Resource IDs is now in numerical order (instead of alphanumerical). That means, the order changes from 1,10,11,... to 1,2,3,...
- The above is observed in (a) the Main Dashboard, where core blocks are now in numerical order and (b) the Node page where also the Resource IDs columns are in numerical order.
- Additionally, the Resource's attributes are also sorted statically with the same sorting function i.e. sort::Naturally. This fixes the fact that a refresh of the Node's page does not modify the order of the attributes randomly.
- For the shake of homogenization, the above function (sort::Naturally) has replaced the respective one (in-built sort) that is applied in Job's attributes.