### PR TITLE
Modified get_data_jobs function

### DIFF
--- a/oar/lib/job_handling.py
+++ b/oar/lib/job_handling.py
@@ -321,7 +321,6 @@ def get_data_jobs(jobs, jids, resource_set, job_security_time, besteffort_durati
 
             if moldable_id != prev_mld_id:
                 if jrg != []:
-                    jrg.append((jr_descriptions, res_constraints))
                     mld_res_rqts.append((prev_mld_id, prev_mld_id_walltime, jrg))
 
                 prev_mld_id = moldable_id
@@ -331,14 +330,6 @@ def get_data_jobs(jobs, jids, resource_set, job_security_time, besteffort_durati
                     prev_mld_id_walltime = besteffort_duration
                 else:
                     prev_mld_id_walltime = mld_id_walltime + job_security_time
-        #
-        # new job resources groupe_id
-        #
-        if jrg_id != prev_jrg_id:
-            prev_jrg_id = jrg_id
-            if jr_descriptions != []:
-                jrg.append((jr_descriptions, res_constraints))
-                jr_descriptions = []
 
         #
         # new set job descriptions
@@ -379,8 +370,15 @@ def get_data_jobs(jobs, jids, resource_set, job_security_time, besteffort_durati
             # add next res_type , res_value
             jr_descriptions.append((res_type, res_value))
 
+        #
+        # new job resources groupe_id
+        #
+        if jrg_id != prev_jrg_id:
+            prev_jrg_id = jrg_id
+            if jr_descriptions != []:
+                jrg.append((jr_descriptions, res_constraints))
+
     # complete the last job
-    jrg.append((jr_descriptions, res_constraints))
     mld_res_rqts.append((prev_mld_id, prev_mld_id_walltime, jrg))
 
     job.mld_res_rqts = mld_res_rqts


### PR DESCRIPTION
I've been trying to run moldable jobs with OAR3 (under the oar-docker-compose environment). I've noticed that, no matter what, the last -l option is the one being selected. For instance, if I attempt to run: `oarsub -I -l nodes=2,walltime=1 -l nodes=1,walltime=2` in an empty cluster of 8 nodes, the job will run on one node for a duration of two hours. But, assuming a cluster as the one mentioned, shouldn't the job run on two nodes for one hour (since this option gives the minimum end time)?

Now, if I change the order of the -l options (i.e.  `oarsub -I -l nodes=1,walltime=2 -l nodes=2,walltime=1`) the job will run on two nodes for a total of one hour. This is why I believe that the last -l option is the one always being selected. 

I made some minor changes in the get_data_jobs function in oar/lib/job_handling.py and from what I can tell they seem to work. I'm making this pull request in case you want to check them out.