### PR TITLE
Fixing resource allocation checks in moldability

### DIFF
--- a/oar/kao/scheduling.py
+++ b/oar/kao/scheduling.py
@@ -289,16 +289,20 @@ def assign_resources_mld_job_split_slots(slots_set, job, hy, min_start_time):
     slots = slots_set.slots
     prev_start_time = slots[1].b
 
+    res_set_nfound=0
+    job.res_set = ProcSet()
+    job.start_time = -1
+    job.moldable_id = -1
+
     for res_rqt in job.mld_res_rqts:
         mld_id, walltime, hy_res_rqts = res_rqt
         res_set, sid_left, sid_right = find_first_suitable_contiguous_slots(
             slots_set, job, res_rqt, hy, min_start_time
         )
         if len(res_set) == 0:  # no suitable time*resources found
-            job.res_set = ProcSet()
-            job.start_time = -1
-            job.moldable_id = -1
-            return
+            res_set_nfound+=1
+            continue
+
         # print("after find fisrt suitable")
         t_finish = slots[sid_left].b + walltime
         if t_finish < prev_t_finish:
@@ -308,6 +312,10 @@ def assign_resources_mld_job_split_slots(slots_set, job, hy, min_start_time):
             prev_res_rqt = res_rqt
             prev_sid_left = sid_left
             prev_sid_right = sid_right
+
+    # no suitable time*resources found for all res_rqt
+    if res_set_nfound == len(job.mld_res_rqts):
+        return
 
     (mld_id, walltime, hy_res_rqts) = prev_res_rqt
     job.moldable_id = mld_id

--- a/oar/lib/job_handling.py
+++ b/oar/lib/job_handling.py
@@ -321,7 +321,6 @@ def get_data_jobs(jobs, jids, resource_set, job_security_time, besteffort_durati
 
             if moldable_id != prev_mld_id:
                 if jrg != []:
-                    jrg.append((jr_descriptions, res_constraints))
                     mld_res_rqts.append((prev_mld_id, prev_mld_id_walltime, jrg))
 
                 prev_mld_id = moldable_id
@@ -331,14 +330,6 @@ def get_data_jobs(jobs, jids, resource_set, job_security_time, besteffort_durati
                     prev_mld_id_walltime = besteffort_duration
                 else:
                     prev_mld_id_walltime = mld_id_walltime + job_security_time
-        #
-        # new job resources groupe_id
-        #
-        if jrg_id != prev_jrg_id:
-            prev_jrg_id = jrg_id
-            if jr_descriptions != []:
-                jrg.append((jr_descriptions, res_constraints))
-                jr_descriptions = []
 
         #
         # new set job descriptions
@@ -379,8 +370,15 @@ def get_data_jobs(jobs, jids, resource_set, job_security_time, besteffort_durati
             # add next res_type , res_value
             jr_descriptions.append((res_type, res_value))
 
+        #
+        # new job resources groupe_id
+        #
+        if jrg_id != prev_jrg_id:
+            prev_jrg_id = jrg_id
+            if jr_descriptions != []:
+                jrg.append((jr_descriptions, res_constraints))
+
     # complete the last job
-    jrg.append((jr_descriptions, res_constraints))
     mld_res_rqts.append((prev_mld_id, prev_mld_id_walltime, jrg))
 
     job.mld_res_rqts = mld_res_rqts


### PR DESCRIPTION
It seems that there is a bug in `oar/kao/scheduling.py` at `assign_resources_mld_job_split_slots` function. In the loop, where no resources are found based on the first configuration (-l), the function returns, where it would be more obvious to check the other given configurations too. For example, in a 4 nodes empty cluster, the execution of the command `oarsub -l /nodes=5,walltime=2 -l /nodes=2,walltime=1 -I` stucks, whereas the second configuration (-l) should lead to reservation.
This PR seems to solve this. The code in PR already integrates the fix mentioned in [PR-11](https://github.com/oar-team/oar3/pull/11).