### PR TITLE
Freezing the major version of SQLAlchemy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ oar-proxy-cleaner = 'oar.cli.oarproxycleaner:cli'
 [tool.poetry.dependencies]
 python = ">=3.9, <4"
 SQLAlchemy-Utils = ">=0.37.3"
-SQLAlchemy = ">=1.4"
+SQLAlchemy = "^1.4.0"
 alembic = ">1.7.0"
 Flask = ">2.0.0"
 tabulate = "^0.8.9"


### PR DESCRIPTION
Temporary workaround to freeze the major version of SQLAlchemy to 1, since all of OAR commands won't work with SQLAlchemy version 2.