### PR TITLE
Allow for API request without trailing slash

### DIFF
--- a/oar/api/routers/job.py
+++ b/oar/api/routers/job.py
@@ -40,6 +40,7 @@ def attach_nodes(job, jobs_resources):
             network_addresses.append(node["network_address"])
 
 
+@router.get("")
 @router.get("/")
 def index(
     user: str = None,
@@ -148,6 +149,7 @@ class SumbitParameters(BaseModel):
     use_job_key: bool = Body(False, alias="use-job-key")
 
 
+@router.post("")
 @router.post("/")
 def submit(sp: SumbitParameters, user: str = Depends(need_authentication)):
     """Job submission

--- a/oar/api/routers/media.py
+++ b/oar/api/routers/media.py
@@ -122,6 +122,7 @@ def ls(
     return data
 
 
+@router.get("")
 @router.get("/")
 def get_file(
     path_filename: str,
@@ -184,6 +185,7 @@ def chmod(path_filename: str, mode: str, user: str = Depends(need_authentication
     return Response(None, status_code=202)
 
 
+@router.api_route("", methods=["POST", "PUT"])
 @router.api_route("/", methods=["POST", "PUT"])
 def post_file(
     request: Request,
@@ -235,6 +237,7 @@ def post_file(
     return data
 
 
+@router.delete("")
 @router.delete("/")
 def delete(path_filename: str, user: str = Depends(need_authentication)):
     path_filename, env = user_and_filename_setup(user, path_filename)

--- a/oar/api/routers/resource.py
+++ b/oar/api/routers/resource.py
@@ -43,6 +43,7 @@ def get_db():
 #     return {"items": resources}
 
 
+@router.get("")
 @router.get("/")
 def index(
     offset: int = 0,
@@ -138,6 +139,7 @@ def state(
     return data
 
 
+@router.post("")
 @router.post("/")
 def create(hostname: str, properties: str, user: str = Depends(need_authentication)):
     """POST /resources"""

--- a/oar/api/routers/stress_factor.py
+++ b/oar/api/routers/stress_factor.py
@@ -31,6 +31,7 @@ if "OARDODO" in config:
     OARDODO_CMD = config["OARDODO"]
 
 
+@router.get("")
 @router.get("/")
 def index():
     stress_factor_script = "/etc/oar/stress_factor.sh"


### PR DESCRIPTION
Issue found while working on Cigri, the job submission was not working with the new API because the API request generated by Cigri is missing a trailing slash. FastAPI answers with a HTTP response 307 (temporary redirect) that Cigri doesn't handle.

The fix was to define in the routers an empty path in addition to the `/`. The order matter, the less restrictive path (or route) on top.