### PR TITLE
Fix commit bbb794b27b9c49ce33804cb1c159caebe953eba6

### DIFF
--- a/oar/cli/oarsub.py
+++ b/oar/cli/oarsub.py
@@ -338,7 +338,6 @@ def connect_job(session, config, job_id, stop_oarexec, openssh_cmd, cmd_ret):
 @click.option(
     "-d",
     "--directory",
-    default=os.getcwd(),
     type=click.STRING,
     help="Specify the directory where to launch the command (default is current directory)",
 )


### PR DESCRIPTION
The commit bbb794b27b9c49ce33804cb1c159caebe953eba6 introduced a bug where `oarsub` was terminated after a few seconds. For instance the command: `oarsub -l /nodes=1 sleep '60'` was not run for 1 min as it was supposed to. Instead, the job is terminated after a few seconds. By removing, this option, it seems that the bug is fixed. This is tested over the docker flavor.