### PR TITLE
feat: add customizable job state notification email templates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,14 @@ OAR: Versatile Resource and Job Manager
 
 OAR is a versatile resource and job manager (also called a batch scheduler or job scheduler) for HPC clusters and other computing infrastructures (like distributed computing experimental testbeds where versatility is a key). This is the third generation.
 
+Features
+--------
+
+* Customizable job state notification emails via text templates.
+
+Links
+-----
+
 * Free software: GPL-2.1 license.
 * Documentation: https://oar-3.readthedocs.org.
 * General Information: http://oar.imag.fr/oar_3.

--- a/etc/oar/templates/mail/default/mail_error.txt
+++ b/etc/oar/templates/mail/default/mail_error.txt
@@ -1,0 +1,27 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ❌ JOB ERROR | #{id} | STATE: {state}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+SUMMARY
+  Job Name    : {name}
+  User        : {user}
+  Project     : {project}
+  Queue       : {queue}
+
+RESOURCES & CONFIGURATION
+  Nodes       : {core_count} node(s) allocated
+  Hostlist    : {nodes}
+  Walltime    : ⏳ {walltime} (limit)
+  Directory   : {dir}
+
+OUTPUT MONITORING
+  Stdout      : {stdout}
+  Stderr      : {stderr}
+
+TECHNICAL INFO
+  Command     : {command}
+  Array Info  : ID {array_id} (Index: {array_index})
+  OAR Message : {message}
+  Exit Code   : {exit_code}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/etc/oar/templates/mail/default/mail_resuming.txt
+++ b/etc/oar/templates/mail/default/mail_resuming.txt
@@ -1,0 +1,27 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ▶️ JOB RESUMING | #{id} | STATE: {state}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+SUMMARY
+  Job Name    : {name}
+  User        : {user}
+  Project     : {project}
+  Queue       : {queue}
+
+RESOURCES & CONFIGURATION
+  Nodes       : {core_count} node(s) allocated
+  Hostlist    : {nodes}
+  Walltime    : ⏳ {walltime} (limit)
+  Directory   : {dir}
+
+OUTPUT MONITORING
+  Stdout      : {stdout}
+  Stderr      : {stderr}
+
+TECHNICAL INFO
+  Command     : {command}
+  Array Info  : ID {array_id} (Index: {array_index})
+  OAR Message : {message}
+  Exit Code   : {exit_code}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/etc/oar/templates/mail/default/mail_running.txt
+++ b/etc/oar/templates/mail/default/mail_running.txt
@@ -1,0 +1,27 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  🚀 JOB STARTING | #{id} | STATE: {state}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+SUMMARY
+  Job Name    : {name}
+  User        : {user}
+  Project     : {project}
+  Queue       : {queue}
+
+RESOURCES & CONFIGURATION
+  Nodes       : {core_count} node(s) allocated
+  Hostlist    : {nodes}
+  Walltime    : ⏳ {walltime} (estimated limit)
+  Directory   : {dir}
+
+OUTPUT MONITORING
+  Stdout      : {stdout}
+  Stderr      : {stderr}
+
+TECHNICAL INFO
+  Command     : {command}
+  Array Info  : ID {array_id} (Index: {array_index})
+  OAR Message : {message}
+  Exit Code   : {exit_code}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/etc/oar/templates/mail/default/mail_suspended.txt
+++ b/etc/oar/templates/mail/default/mail_suspended.txt
@@ -1,0 +1,27 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ⏸️ JOB SUSPENDED | #{id} | STATE: {state}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+SUMMARY
+  Job Name    : {name}
+  User        : {user}
+  Project     : {project}
+  Queue       : {queue}
+
+RESOURCES & CONFIGURATION
+  Nodes       : {core_count} node(s) allocated
+  Hostlist    : {nodes}
+  Walltime    : ⏳ {walltime} (limit)
+  Directory   : {dir}
+
+OUTPUT MONITORING
+  Stdout      : {stdout}
+  Stderr      : {stderr}
+
+TECHNICAL INFO
+  Command     : {command}
+  Array Info  : ID {array_id} (Index: {array_index})
+  OAR Message : {message}
+  Exit Code   : {exit_code}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/etc/oar/templates/mail/default/mail_terminated.txt
+++ b/etc/oar/templates/mail/default/mail_terminated.txt
@@ -1,0 +1,27 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ✅ JOB TERMINATED | #{id} | STATE: {state}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+SUMMARY
+  Job Name    : {name}
+  User        : {user}
+  Project     : {project}
+  Queue       : {queue}
+
+RESOURCES & CONFIGURATION
+  Nodes       : {core_count} node(s) allocated
+  Hostlist    : {nodes}
+  Walltime    : ⏳ {walltime} (limit)
+  Directory   : {dir}
+
+OUTPUT MONITORING
+  Stdout      : {stdout}
+  Stderr      : {stderr}
+
+TECHNICAL INFO
+  Command     : {command}
+  Array Info  : ID {array_id} (Index: {array_index})
+  OAR Message : {message}
+  Exit Code   : {exit_code}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/oar/lib/job_handling.py
+++ b/oar/lib/job_handling.py
@@ -1,5 +1,6 @@
 # coding: utf-8
-""" Functions to handle jobs"""
+"""Functions to handle jobs"""
+
 import copy
 import os
 import random
@@ -202,7 +203,7 @@ def set_jobs_cache_keys(session, jobs):
     for job_id, job in jobs.items():
         if (not job.ts) and (job.ph == NO_PLACEHOLDER):
             for res_rqt in job.mld_res_rqts:
-                (moldable_id, walltime, hy_res_rqts) = res_rqt
+                moldable_id, walltime, hy_res_rqts = res_rqt
                 job.key_cache[int(moldable_id)] = str(walltime) + str(hy_res_rqts)
 
 
@@ -931,7 +932,7 @@ def insert_job(session, **kwargs):
         moldable_id = mld_ids[mld_idx]
 
         for r_hy_prop in res_grp:
-            (res_hy, properties) = r_hy_prop
+            res_hy, properties = r_hy_prop
             mld_id_property.append(
                 {"res_group_moldable_id": moldable_id, "res_group_property": properties}
             )
@@ -1745,11 +1746,29 @@ def set_job_state(session, config, jid, state):
         ):
             job = session.query(Job).filter(Job.id == jid).one()
             if state == "Suspended":
-                tools.notify_user(session, job, "SUSPENDED", "Job is suspended.")
+                tools.notify_user(
+                    session,
+                    job,
+                    "SUSPENDED",
+                    get_custom_notification_message(config, state, job, session, jid)
+                    or "Job is suspended.",
+                )
             elif state == "Resuming":
-                tools.notify_user(session, job, "RESUMING", "Job is resuming.")
+                tools.notify_user(
+                    session,
+                    job,
+                    "RESUMING",
+                    get_custom_notification_message(config, state, job, session, jid)
+                    or "Job is resuming.",
+                )
             elif state == "Running":
-                tools.notify_user(session, job, "RUNNING", "Job is running.")
+                tools.notify_user(
+                    session,
+                    job,
+                    "RUNNING",
+                    get_custom_notification_message(config, state, job, session, jid)
+                    or "Job is running.",
+                )
             elif state == "toLaunch":
                 update_current_scheduler_priority(session, config, job, "+2", "START")
             else:  # job is "Terminated" or ($state eq "Error")
@@ -1766,7 +1785,15 @@ def set_job_state(session, config, jid, state):
                     )
 
                 if state == "Terminated":
-                    tools.notify_user(session, job, "END", "Job stopped normally.")
+                    tools.notify_user(
+                        session,
+                        job,
+                        "END",
+                        get_custom_notification_message(
+                            config, state, job, session, jid
+                        )
+                        or "Job stopped normally.",
+                    )
                 else:
                     # Verify if the job was suspended and if the resource
                     # property suspended is updated
@@ -1789,7 +1816,10 @@ def set_job_state(session, config, jid, state):
                         session,
                         job,
                         "ERROR",
-                        "Job stopped abnormally or an OAR error occured.",
+                        get_custom_notification_message(
+                            config, state, job, session, jid
+                        )
+                        or "Job stopped abnormally or an OAR error occured.",
                     )
 
                 update_current_scheduler_priority(session, config, job, "-2", "STOP")
@@ -2547,7 +2577,7 @@ def job_finishing_sequence(session, config, epilogue_script, job_id, events):
             + str(hosts)
         )
 
-        (pingcheck, bad_hosts) = tools.pingchecker(hosts)
+        pingcheck, bad_hosts = tools.pingchecker(hosts)
 
         if (pingcheck and len(bad_hosts) > 0) or not pingcheck:
             if pingcheck:
@@ -2849,9 +2879,7 @@ WHERE
       t.type = 'besteffort' )
   ) AND
   gr.resource_id IN ( {} )
-    """.format(
-        only_adv_reservations, from_, to, exclude, resources_str
-    )
+    """.format(only_adv_reservations, from_, to, exclude, resources_str)
     raw_start_times = session.get_bind().execute(text(req))
 
     for start_time in raw_start_times.fetchall():
@@ -2869,3 +2897,67 @@ def change_walltime(session, job_id, new_walltime, message):
     session.commit()
     add_new_event(session, "WALLTIME", job_id, message, to_check="NO")
     session.commit()
+
+
+def get_custom_notification_message(config, state, job, session, jid):
+    """
+    Generates a custom notification message based on text templates.
+
+    Returns the message body as a string.
+    Returns None in case of an error (missing or malformed template),
+    forcing OAR to fallback to its default notification system.
+    """
+    path = config.get(f"MAIL_TEMPLATE_{state.upper()}")
+    if not (path and os.path.isfile(path)):
+        return None
+
+    # 1. Standard dictionary with safe default values
+    data = {
+        "id": jid,
+        "user": getattr(job, "user", "unknown"),
+        "state": state,
+        "name": getattr(job, "name", "N/A") or "N/A",
+        "project": getattr(job, "project", "N/A"),
+        "queue": getattr(job, "queue_name", "N/A"),
+        "dir": getattr(job, "launching_directory", "N/A"),
+        "command": getattr(job, "command", "N/A"),
+        "stdout": (getattr(job, "stdout_file", "") or "").replace("%jobid%", str(jid)),
+        "stderr": (getattr(job, "stderr_file", "") or "").replace("%jobid%", str(jid)),
+        "exit_code": getattr(job, "exit_code", "N/A"),
+        "message": getattr(job, "message", ""),
+        "array_id": getattr(job, "array_id", jid),
+        "array_index": getattr(job, "array_index", "1"),
+        "nodes": "N/A",
+        "core_count": 0,
+        "walltime": "N/A",
+    }
+
+    # 2. Nodes block (Independent)
+    try:
+        node_list = get_job_current_hostnames(session, jid)
+        if node_list:
+            data["nodes"] = ", ".join(node_list)
+            data["core_count"] = len(node_list)
+    except Exception as e:
+        logger.debug(f"[OAR_CUSTOM_MAIL] Nodes extraction failed for job {jid}: {e}")
+
+    # 3. Walltime block (Independent)
+    try:
+        m_id = getattr(job, "assigned_moldable_job", 0)
+        if m_id:
+            mld = session.query(MoldableJobDescription).filter_by(id=m_id).first()
+            if mld and mld.walltime:
+                data["walltime"] = (
+                    f"{mld.walltime // 3600}h {(mld.walltime % 3600) // 60}m"
+                )
+    except Exception as e:
+        logger.debug(f"[OAR_CUSTOM_MAIL] Walltime extraction failed for job {jid}: {e}")
+
+    # 4. Final rendering (Secure with fallback on formatting error)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read().format(**data)
+    except Exception as e:
+        # Catch KeyError if a template tag is misspelled
+        logger.error(f"[OAR_CUSTOM_MAIL] Template formatting error on '{path}': {e}")
+        return None

--- a/oar/tools/oar.conf.in
+++ b/oar/tools/oar.conf.in
@@ -189,6 +189,18 @@ PINGCHECKER_SENTINELLE_SCRIPT_COMMAND="%%OARDIR%%/sentinelle.pl -t 30 -w 20"
 #MAIL_RECIPIENT="user@domain.com"
 #MAIL_SENDER="oar@domain.com"
 
+#######################################
+# Custom Mail Templates Configuration #
+###############################################################################
+# Path to the text files used as templates for job notifications.
+# If a file is missing or the line is commented out, OAR will use
+# the default hardcoded messages.
+#MAIL_TEMPLATE_RUNNING="/etc/oar/templates/mail/default/mail_running.txt"
+#MAIL_TEMPLATE_TERMINATED="/etc/oar/templates/mail/default/mail_terminated.txt"
+#MAIL_TEMPLATE_ERROR="/etc/oar/templates/mail/default/mail_error.txt"
+#MAIL_TEMPLATE_SUSPENDED="/etc/oar/templates/mail/default/mail_suspended.txt"
+#MAIL_TEMPLATE_RESUMING="/etc/oar/templates/mail/default/mail_resuming.txt"
+
 ###############################################################################
 
 ###########

--- a/tests/lib/test_job_handling.py
+++ b/tests/lib/test_job_handling.py
@@ -10,6 +10,7 @@ from oar.lib.job_handling import (
     get_data_jobs,
     insert_job,
     job_message,
+    get_custom_notification_message,
 )
 from oar.lib.models import EventLog, Job
 
@@ -160,3 +161,44 @@ def test_job_message(minimal_db_initialization):
 
     result_without_name = job_message(session, job_without_name)
     assert "N=" not in result_without_name
+
+
+def test_get_custom_notification_message(
+    minimal_db_initialization, setup_config, tmp_path
+):
+    config, _ = setup_config
+    session = minimal_db_initialization
+
+    # Create a test job
+    job_id = insert_job(
+        session,
+        res=[(60, [("resource_id=4", "")])],
+        properties="",
+        state="Running",
+        job_user="Toto",
+    )
+    job = session.query(Job).filter(Job.id == job_id).one()
+
+    # Case 1: No template configured -> Must return None
+    assert (
+        get_custom_notification_message(config, "RUNNING", job, session, job_id) is None
+    )
+
+    # Case 2: Valid template -> Must replace the tags
+    valid_tpl = tmp_path / "valid.txt"
+    valid_tpl.write_text("Hello {user}, Job {id} is {state}")
+    config["MAIL_TEMPLATE_RUNNING"] = str(valid_tpl)
+
+    res = get_custom_notification_message(config, "RUNNING", job, session, job_id)
+    assert res is not None
+    assert "Hello Toto" in res
+    assert f"Job {job_id} is RUNNING" in res
+
+    # Case 3: Invalid template -> Must return None without crashing
+    bad_tpl = tmp_path / "bad.txt"
+    bad_tpl.write_text("Crash {unknown_variable}")
+    config["MAIL_TEMPLATE_ERROR"] = str(bad_tpl)
+
+    assert (
+        get_custom_notification_message(config, "ERROR", job, session, job_id) is None
+    )


### PR DESCRIPTION
### Context
This commit introduces the ability for administrators to fully customize the notification emails sent to users upon various job state changes (Running, Terminated, Error, Suspended, Resuming) using simple text templates.

It features a robust, safe-fail mechanism: if a configured template is missing, malformed, or contains unknown formatting tags, OAR will gracefully fall back to its default hardcoded notification strings without interrupting the scheduler.

### Changes
- **`oar/lib/job_handling.py`**:
  * Implemented `get_custom_notification_message` with safe dictionary mapping and `try/except` blocks.
  * Modified `set_job_state` to inject custom templates into `tools.notify_user`, using the `or` operator for seamless fallbacks.
- **`etc/oar/templates/mail/default/`**: Added 5 default rich-text template examples (`mail_running.txt`, `mail_terminated.txt`, `mail_error.txt`, `mail_suspended.txt`, `mail_resuming.txt`).
- **`oar/tools/oar.conf.in`**: Added commented configuration variables (`MAIL_TEMPLATE_RUNNING`, `MAIL_TEMPLATE_TERMINATED`, etc.) to link the templates.
- **`tests/lib/test_job_handling.py`**: Added `test_get_custom_notification_message` to validate template formatting, missing configs, and bad syntax handling using Pytest.
- **`README.rst`**: Added a "Features" section to document this new capability.