### PR TITLE
fix: add missing ENERGY_SAVING_MODE variable to oar.conf

### DIFF
--- a/oar/tools/oar.conf.in
+++ b/oar/tools/oar.conf.in
@@ -496,6 +496,10 @@ SCHEDULER_FAIRSHARING_MAX_JOB_PER_USER=30
 # Possible values are "yes" and "no"
 ENERGY_SAVING_INTERNAL="no"
 
+# Energy saving decision coordination mode.
+# Required for OAR to automatically shut down and wake up nodes.
+#ENERGY_SAVING_MODE="metascheduler_decision_making"
+
 # The internal energy saving module is "GRETA"
 # Communication port of GRETA wan be changed here.
 # Default: localhost on 6672


### PR DESCRIPTION
### Context
The `ENERGY_SAVING_MODE` variable is functional within the OAR3 source code, but it was completely missing from the default `oar.conf` template file. This made it difficult for administrators to discover and configure the coordination mode for automated power management.

### Changes
This PR adds the `#ENERGY_SAVING_MODE="metascheduler_decision_making"` variable to the `ENERGY SAVING` section of the default `oar.conf` file. 

- It is commented out by default to match the file's standard layout.
- It includes a brief comment explaining that this option coordinates power management decisions and is required for OAR to automatically shut down and wake up nodes.